### PR TITLE
[FIX] End call when closing PIP (Android)

### DIFF
--- a/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPluginActivity.kt
+++ b/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPluginActivity.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.gunschu.jitsi_meet.JitsiMeetPlugin.Companion.JITSI_PLUGIN_TAG
 import org.jitsi.meet.sdk.JitsiMeetActivity
 import org.jitsi.meet.sdk.JitsiMeetConferenceOptions
+import android.content.res.Configuration
 
 /**
  * Activity extending JitsiMeetActivity in order to override the conference events
@@ -22,7 +23,32 @@ class JitsiMeetPluginActivity: JitsiMeetActivity() {
             context?.startActivity(intent)
         }
     }
-    
+
+    var onStopCalled: Boolean = false;
+
+    override fun onPictureInPictureModeChanged( isInPictureInPictureMode: Boolean, newConfig: Configuration?)
+    {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+
+        if (isInPictureInPictureMode == false && onStopCalled)
+        {
+            // Picture-in-Picture mode has been closed, we can (should !) end the call
+            getJitsiView().leave()
+        }
+    }
+
+    override fun onStop()
+    {
+        super.onStop()
+        onStopCalled = true;
+    }
+
+    override fun onResume()
+    {
+        super.onResume()
+        onStopCalled = false;
+    }
+
     override fun onConferenceWillJoin(data: MutableMap<String, Any>?) {
         Log.d(JITSI_PLUGIN_TAG, String.format("JitsiMeetPluginActivity.onConferenceWillJoin: %s", data))
         JitsiMeetEventStreamHandler.instance.onConferenceWillJoin(data)
@@ -36,6 +62,7 @@ class JitsiMeetPluginActivity: JitsiMeetActivity() {
     }
 
     override fun onConferenceTerminated(data: MutableMap<String, Any>?) {
+
         Log.d(JITSI_PLUGIN_TAG, String.format("JitsiMeetPluginActivity.onConferenceTerminated: %s", data))
         JitsiMeetEventStreamHandler.instance.onConferenceTerminated(data)
         super.onConferenceTerminated(data)


### PR DESCRIPTION
This modification fixes and issue on Android where you can exit the PIP mode (sliding it down your screen) without ending the call. This can really be an issue, because the user doesn't know he's still in call, until he tries to go into another call.

This implementation checks if a `onStop` has been raised before the `onPictureInPictureModeChanged`, and if the mode changed from PIP to Fullscreen.

(Related with #8 )