### PR TITLE
Room name constraints

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:jitsi_meet/jitsi_meet.dart';
 import 'package:jitsi_meet/jitsi_meeting_listener.dart';
+import 'package:jitsi_meet/room_name_constraint.dart';
+import 'package:jitsi_meet/room_name_constraint_type.dart';
 
 void main() => runApp(MyApp());
 
@@ -206,11 +208,26 @@ class _MyAppState extends State<MyApp> {
             debugPrint("${options.room} joined with message: $message");
           }, onConferenceTerminated: ({message}) {
             debugPrint("${options.room} terminated with message: $message");
-          }));
+          }),
+          // by default, plugin default constraints are used
+          //roomNameConstraints: new Map(), // to disable all constraints
+          //roomNameConstraints: customContraints, // to use your own constraint(s)
+      );
     } catch (error) {
       debugPrint("error: $error");
     }
   }
+
+  static final Map<RoomNameConstraintType, RoomNameConstraint> customContraints =
+  {
+    RoomNameConstraintType.MAX_LENGTH : new RoomNameConstraint(
+            (value) { return value.trim().length <= 50; },
+            "Maximum room name length should be 30."),
+
+    RoomNameConstraintType.FORBIDDEN_CHARS : new RoomNameConstraint(
+            (value) { return RegExp(r"[$€£]+", caseSensitive: false, multiLine: false).hasMatch(value) == false; },
+            "Currencies characters aren't allowed in room names."),
+  };
 
   void _onConferenceWillJoin({message}) {
     debugPrint("_onConferenceWillJoin broadcasted with message: $message");

--- a/lib/room_name_constraint.dart
+++ b/lib/room_name_constraint.dart
@@ -1,0 +1,23 @@
+
+class RoomNameConstraint
+{
+  Function(String) _checkFunction;
+  String _constraintMessage;
+
+  RoomNameConstraint(Function(String) checkFunction, String constraintMessage)
+  {
+    _checkFunction = checkFunction;
+    _constraintMessage = constraintMessage;
+  }
+
+  bool checkConstraint(String value)
+  {
+    return _checkFunction(value);
+  }
+
+  String getMessage()
+  {
+    return _constraintMessage;
+  }
+
+}

--- a/lib/room_name_constraint_type.dart
+++ b/lib/room_name_constraint_type.dart
@@ -1,0 +1,8 @@
+
+enum RoomNameConstraintType
+{
+  MIN_LENGTH,
+  MAX_LENGTH,
+  ALLOWED_CHARS,
+  FORBIDDEN_CHARS
+}


### PR DESCRIPTION
For my project, I needed to modify constraints put on room names. I found out that it would be easier to be able to use, override or suppress them, without modifying the plugin. Moreover, they can be reused, for example in the `validator` method of a `TextFormField`, and it avoids redundancy.

Of course, I'm open to modifications, and I hope that this feature could be useful to people, if not then this PR can be closed.

## Features implemented
- Same behavior as original code by default
- Anybody can give an empty `Map` to the `joinMeeting` method to disable all constraints
- Anybody can build a custom constraints `Map` and give it to the `joinMeeting` method to use them
- Default constraints or custom constraints can be reused, in `validator` method for example
- Each constraint is made of a type (`RoomNameConstraintType`) and a message (`String`), giving you the possibility to put a generic message and localize it in many languages if you display it under a `TextFormField` (or anything) after validation

## Modifications related to this
- `enum RoomNameConstraintType` with `MIN_LENGTH` and `ALLOWED_CHARS` (replacing original code ones) but also `MAX_LENGTH` and `FORBIDDEN_CHARS` for those who would need it
- `class RoomNameConstraint` to create a constraint with a type and a message associated
- `Map<RoomNameConstraintType, RoomNameConstraint>` ensuring each type of constraint is only present once
- In debug, `for` loop on that `Map` with an `assert()` instruction
- In production, the user can use it where he needs it
-> Using the same constraints for debug and prod avoids redundancy and reduce errors

**Of course, this may need more documentation than comments in the code and PR description, but I'm curious about what you may think of that feature first**