### PR TITLE
Updated to Jitsi SDK 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1
+* Updated JitsiMeet SDK to v2.9.0 
+
 ## 0.2.0
 * Added IOSAppBarRGBAColor Param
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Jitsi Meet from https://github.com/jitsi/jitsi-maven-repository/tree/master/releases/org/jitsi/react/jitsi-meet-sdk
-    implementation ('org.jitsi.react:jitsi-meet-sdk:2.8.2') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:2.9.0') { transitive = true }
 }

--- a/ios/jitsi_meet.podspec
+++ b/ios/jitsi_meet.podspec
@@ -15,7 +15,7 @@ Jitsi Meet Plugin
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'JitsiMeetSDK', '2.8.1'
+  s.dependency 'JitsiMeetSDK', '2.9.0'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
Tested it on Android and iOS -> everything worked for me 👍