### PR TITLE
Feature flags implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Find more information about Jitsi Meet [here](https://github.com/jitsi/jitsi-mee
   * [ Android](#android)
 * [ Join A Meeting](#join-a-meeting)
 * [ JitsiMeetingOptions](#jitsimeetingoptions)
+  *[ FeatureFlags](#featureflags)
 * [ JitsiMeetingResponse](#jitsimeetingresponse)
 * [ Listening to Meeting Events](#listening-to-meeting-events)
 * [ Contributing](#contributing)
@@ -129,6 +130,7 @@ W/unknown:ViewManagerPropertyUpdater: Could not find generated setter for class 
 ```
 
 <a name="join-a-meeting"></a>
+
 ### Join A Meeting
 
 ```dart
@@ -152,26 +154,58 @@ _joinMeeting() async {
 ```
 
 <a name="jitsimeetingoptions"></a>
+
 ### JitsiMeetingOptions
 
-| Field           | Required  | Default   | Description |
-| --------------- | --------- | --------- | ----------- |
-| room            | Yes       | N/A              | Unique room name that will be appended to serverURL. Valid characters: alphanumeric, dashes, and underscores. |
-| subject         | No        | $room            | Meeting name displayed at the top of the meeting.  If null, defaults to room name where dashes and underscores are replaced with spaces and first characters are capitalized. |
-| userDisplayName | No        | "Fellow Jitster" | User's display name |
-| userEmail       | No        | none             | User's email address |
-| audioOnly       | No        | false            | Start meeting without video. Can be turned on in meeting. |
-| audioMuted      | No        | false            | Start meeting with audio muted. Can be turned on in meeting. |
-| videoMuted      | No        | false            | Start meeting with video muted. Can be turned on in meeting. |
-| serverURL       | No        | meet.jitsi.si    | Specify your own hosted server. Must be a valid absolute URL of the format `<scheme>://<host>[/path]`, i.e. https://someHost.com. Defaults to Jitsi Meet's servers. |
-| userAvatarURL   | N/A       | none             | *Not yet implemented*. User's avatar URL. |
-| token           | N/A       | none             | *Not yet implemented*. JWT token used for authentication. |
-| iosAppBarRGBAColor| No       | "00000000"      | only IOS, only RGBA values accepted |
+| Field             | Required  | Default           | Description |
+ ------------------ | --------- | ----------------- | ----------- |
+| room              | Yes       | N/A               | Unique room name that will be appended to serverURL. Valid characters: alphanumeric, dashes, and underscores. |
+| subject           | No        | $room             | Meeting name displayed at the top of the meeting.  If null, defaults to room name where dashes and underscores are replaced with spaces and first characters are capitalized. |
+| userDisplayName   | No        | "Fellow Jitster"  | User's display name |
+| userEmail         | No        | none              | User's email address |
+| audioOnly         | No        | false             | Start meeting without video. Can be turned on in meeting. |
+| audioMuted        | No        | false             | Start meeting with audio muted. Can be turned on in meeting. |
+| videoMuted        | No        | false             | Start meeting with video muted. Can be turned on in meeting. |
+| serverURL         | No        | meet.jitsi.si     | Specify your own hosted server. Must be a valid absolute URL of the format `<scheme>://<host>[/path]`, i.e. https://someHost.com. Defaults to Jitsi Meet's servers. |
+| userAvatarURL     | N/A       | none              | *Not yet implemented*. User's avatar URL. |
+| token             | N/A       | none              | *Not yet implemented*. JWT token used for authentication. |
+| iosAppBarRGBAColor| No        | "00000000"        | only IOS, only RGBA values accepted |
+| featureFlags      | No        | see below         | Map of feature flags and their values (true/false), used to enable/disable features of the Jitsi Meet SDK |
 
 A new param has been added iosAppBarRGBAColor . This will change the AppBar color of the View in IOS only. 
 Please note : the ioaAppBarRGBAColor param takes RGBA color format only .. for example Black - "00000000". 
 
 <a name="jitsimeetingresponse"></a>
+
+#### FeatureFlags
+
+Feature flags allow you to enable or disable any feature of the Jitsi Meet SDK.  
+If you don't provide any flag to JitsiMeetingOptions, default values will be used.  
+If you don't provide a flag in featureFlags in JitsiMeetingOptions, its default value will be used.  
+We are using the [official list of flags, taken from the Jitsi Meet repository](https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/flags/constants.js)
+
+| Flag | Default (Android) | Default (iOS) | Description |
+| ------------------------------ | ----- | ----- | ----------- |
+| `ADD_PEOPLE_ENABLED`          | true  | true  | Enable the blue button "Add people", showing up when you are alone in a call. Requires flag `INVITE_ENABLED` to work. |
+| `CALENDAR_ENABLED`            | true  | auto  | Enable calendar integration. |
+| `CALL_INTEGRATION_ENABLED`    | true  | true  | Enable call integration (CallKit on iOS, ConnectionService on Android). **SEE REMARK BELOW** |
+| `CLOSE_CAPTIONS_ENABLED`      | true  | true  | Enable close captions (subtitles) option in menu. |
+| `CHAT_ENABLED`                | true  | true  | Enable chat (button and feature). |
+| `INVITE_ENABLED`              | true  | true  | Enable invite option in menu. |
+| `IOS_RECORDING_ENABLED`       | N/A   | false | Enable recording in iOS. |
+| `LIVE_STREAMING_ENABLED`      | auto  | auto  | Enable live-streaming option in menu. |
+| `MEETING_NAME_ENABLED`        | true  | true  | Display meeting name. |
+| `MEETING_PASSWORD_ENABLED`    | true  | true  | Display meeting password option in menu (if a meeting has a password set, the dialog will still show up). |
+| `PIP_ENABLED`                 | auto  | auto  | Enable Picture-in-Picture mode. |
+| `RAISE_HAND_ENABLED`          | true  | true  | Enable raise hand option in menu. |
+| `RAISE_HAND_ENABLED`          | true  | true  | Enable raise hand option in menu. |
+| `RECORDING_ENABLED`           | auto  | N/A   | Enable recording option in menu. |
+| `TILE_VIEW_ENABLED`           | true  | true  | Enable tile view option in menu. |
+| `TILE_VIEW_ENABLED`           | true  | true  | Toolbox (buttons and menus) always visible during call (if not, a single tap displays it). |
+| `WELCOME_PAGE_ENABLED`        | false | false | Enable welcome page. "The welcome page lists recent meetings and calendar appointments and it's meant to be used by standalone applications." |
+
+**REMARK about Call integration** Call integration on Android (known as ConnectionService) [has been disabled on the official Jitsi Meet app](https://github.com/jitsi/jitsi-meet/commit/95eb551156c6769e25be9855dd2bc21adf71ac76) because it creates a lot of issues. You should disable it too to avoid these issues.
+
 ### JitsiMeetingResponse
 
 | Field           | Type    | Description |
@@ -181,6 +215,7 @@ Please note : the ioaAppBarRGBAColor param takes RGBA color format only .. for e
 | error           | dynamic | Optional, only exists if isSuccess is false. The error object. |
 
 <a name="listening-to-meeting-events"></a>
+
 ### Listening to Meeting Events
 
 Events supported
@@ -262,6 +297,7 @@ Also in Info.plist add the following
 This will ensure the right permissions are configured in your project. 
 
 <a name="contributing"></a>
+
 ## Contributing
 Send a pull request with as much information as possible clearly 
 describing the issue or feature. Try to keep changes small and 

--- a/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPlugin.kt
+++ b/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPlugin.kt
@@ -118,9 +118,10 @@ public class JitsiMeetPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware
         val serverURL = URL(serverURLString)
         Log.d(JITSI_PLUGIN_TAG, "Server URL: $serverURL, $serverURLString")
 
-        // Build options object for joining the conference. The SDK will merge the default
-        // one we set earlier and this one when joining.
-        val options = JitsiMeetConferenceOptions.Builder()
+        val optionsBuilder = JitsiMeetConferenceOptions.Builder()
+
+        // Set meeting options
+        optionsBuilder
                 .setServerURL(serverURL)
                 .setRoom(room)
                 .setSubject(call.argument("subject"))
@@ -129,17 +130,16 @@ public class JitsiMeetPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware
                 .setAudioOnly(call.argument("audioOnly") ?: false)
                 .setVideoMuted(call.argument("videoMuted") ?: false)
                 .setUserInfo(userInfo)
-                .setFeatureFlag("pip.enabled", call.argument("pipEnabled") ?: false)
-                .setFeatureFlag("add-people.enabled", call.argument("addpeopleEnabled") ?: false)
-                .setFeatureFlag("calendar.enabled", call.argument("calendarEnabled") ?: false)
-                .setFeatureFlag("chat.enabled", call.argument("chatEnabled") ?: false)
-                .setFeatureFlag("invite.enabled", call.argument("inviteEnabled") ?: false)
-                .setFeatureFlag("live-streaming.enabled", false)
-                .setFeatureFlag("recording.enabled", false)
-                .setFeatureFlag("toolbox.alwaysVisible", false)
-                .setFeatureFlag("welcomepage.enabled", false)
-                .setWelcomePageEnabled(false)
-                .build()
+
+        // Add feature flags into options, reading given Map
+        if(call.argument<HashMap<String, Boolean>?>("featureFlags") != null)
+        {
+            val featureFlags = call.argument<HashMap<String, Boolean>>("featureFlags")
+            featureFlags!!.forEach { (key, value) -> optionsBuilder.setFeatureFlag(key, value) }
+        }
+
+        // Build with meeting options and feature flags
+        val options = optionsBuilder.build()
 
         JitsiMeetPluginActivity.launchActivity(activity, options)
         result.success("Successfully joined room: $room")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:jitsi_meet/jitsi_meet.dart';
@@ -196,9 +198,20 @@ class _MyAppState extends State<MyApp> {
       // Full list of feature flags (and defaults) available in the README
       Map<FeatureFlagEnum, bool> featureFlags =
       {
-        FeatureFlagEnum.CALL_INTEGRATION_ENABLED : false,
         FeatureFlagEnum.WELCOME_PAGE_ENABLED : false,
       };
+
+      // Here is an example, disabling features for each platform
+      if (Platform.isAndroid)
+      {
+        // Disable ConnectionService usage on Android to avoid issues (see README)
+        featureFlags[FeatureFlagEnum.CALL_INTEGRATION_ENABLED] = false;
+      }
+      else if (Platform.isIOS)
+      {
+        // Disable PIP on iOS as it looks weird
+        featureFlags[FeatureFlagEnum.PIP_ENABLED] = false;
+      }
 
       // Define meetings options here
       var options = JitsiMeetingOptions()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:jitsi_meet/jitsi_meet.dart';
 import 'package:jitsi_meet/jitsi_meeting_listener.dart';
 import 'package:jitsi_meet/room_name_constraint.dart';
 import 'package:jitsi_meet/room_name_constraint_type.dart';
+import 'package:jitsi_meet/feature_flag/feature_flag_enum.dart';
 
 void main() => runApp(MyApp());
 
@@ -189,6 +190,17 @@ class _MyAppState extends State<MyApp> {
         serverText.text?.trim()?.isEmpty ?? "" ? null : serverText.text;
 
     try {
+
+      // Enable or disable any feature flag here
+      // If feature flag are not provided, default values will be used
+      // Full list of feature flags (and defaults) available in the README
+      Map<FeatureFlagEnum, bool> featureFlags =
+      {
+        FeatureFlagEnum.CALL_INTEGRATION_ENABLED : false,
+        FeatureFlagEnum.WELCOME_PAGE_ENABLED : false,
+      };
+
+      // Define meetings options here
       var options = JitsiMeetingOptions()
         ..room = roomText.text
         ..serverURL = serverUrl
@@ -198,7 +210,8 @@ class _MyAppState extends State<MyApp> {
         ..iosAppBarRGBAColor = iosAppBarRGBAColor.text
         ..audioOnly = isAudioOnly
         ..audioMuted = isAudioMuted
-        ..videoMuted = isVideoMuted;
+        ..videoMuted = isVideoMuted
+        ..featureFlags.addAll(featureFlags);
 
       debugPrint("JitsiMeetingOptions: $options");
       await JitsiMeet.joinMeeting(options,

--- a/ios/Classes/JitsiViewController.swift
+++ b/ios/Classes/JitsiViewController.swift
@@ -15,11 +15,7 @@ class JitsiViewController: UIViewController {
     var audioOnly:Bool? = false
     var audioMuted: Bool? = false
     var videoMuted: Bool? = false
-    var pipEnabled: Bool? = false
-    var addPeopleEnabled: Bool? = false
-    var calendarEnabled: Bool? = false
-    var chatEnabled: Bool? = false
-    var inviteEnabled: Bool? = false
+    var featureFlags: Dictionary<String, Bool>? = Dictionary();
     var appBarColor: UIColor? = UIColor(hex: "#00000000")
     
     var jistiMeetUserInfo = JitsiMeetUserInfo()
@@ -74,15 +70,11 @@ class JitsiViewController: UIViewController {
             builder.audioOnly = self.audioOnly ?? false
             builder.audioMuted = self.audioMuted ?? false
             builder.videoMuted = self.videoMuted ?? false
-            builder.setFeatureFlag("pip.enabled", withValue: self.pipEnabled ?? false)
-            builder.setFeatureFlag("add-people.enabled", withValue: self.addPeopleEnabled ?? false)
-            builder.setFeatureFlag("calendar.enabled", withValue: self.calendarEnabled ?? false)
-            builder.setFeatureFlag("chat.enabled", withValue: self.chatEnabled ?? false)
-            builder.setFeatureFlag("invite.enabled", withValue: self.inviteEnabled ?? false)
-            builder.setFeatureFlag("live-streaming.enabled", withValue: false)
-            builder.setFeatureFlag("recording.enabled", withValue: false)
-            builder.setFeatureFlag("toolbox.alwaysVisible", withValue: true)
-            builder.setFeatureFlag("welcomepage.enabled", withValue: false)
+            
+            self.featureFlags?.forEach{ key,value in
+                builder.setFeatureFlag(key, withValue: value);
+            }
+            
         }
         
         jitsiMeetView.join(options)

--- a/ios/Classes/SwiftJitsiMeetPlugin.swift
+++ b/ios/Classes/SwiftJitsiMeetPlugin.swift
@@ -56,14 +56,14 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                     jitsiViewController?.roomName = roomName;
                     jitsiViewController?.subject = subject;
                     jitsiViewController?.jistiMeetUserInfo.displayName = displayName;
-                    jitsiViewController?.jistiMeetUserInfo.email = email;
-                    
+                    jitsiViewController?.jistiMeetUserInfo.email = email;                    
                  
                     jitsiViewController?.appBarColor = UIColor(hex: appBarColor ??  "#00000000")
                     
                     //                    let avatar = myArgs["userAvatarURL"] as? String,
                     //                    let avatarURL  = URL(string: avatar)
                     //                    jitsiViewController?.jistiMeetUserInfo.avatar = avatarURL;
+                    
                     if let audioOnly = myArgs["audioOnly"] as? Int {
                         let audioOnlyBool = audioOnly > 0 ? true : false
                         jitsiViewController?.audioOnly = audioOnlyBool;
@@ -79,23 +79,17 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                         jitsiViewController?.videoMuted = videoMutedBool;
                     }
                     
+                    if let featureFlags = myArgs["featureFlags"] as? Dictionary<String, Bool>
+                    {
+                        jitsiViewController?.featureFlags = featureFlags;
+                    }
+                    
                 } else {
                     result(FlutterError.init(code: "400", message: "room is null in arguments for method: (joinMeeting)", details: "room is null in arguments for method: (joinMeeting)"))
                 }
             } else {
                 result(FlutterError.init(code: "400", message: "arguments are null for method: (joinMeeting)", details: "arguments are null for method: (joinMeeting)"))
             }
-            
-            
-            //jitsiViewController!.roomName = call.arguments!["room"] as? String;
-            // jitsiViewController!.subject = call.arguments!["subject"] as? String;
-            // jitsiViewController?.jistiMeetUserInfo.displayName = call.arguments?["userDisplayName"] as? String;
-            // jitsiViewController?.jistiMeetUserInfo.email = call.arguments?["userEmail"] as? String;
-            // jitsiViewController?.jistiMeetUserInfo.avatar = call.arguments["userAvatarURL"] as? URL;
-            //jitsiViewController.serverURL = call.argument["serverURL"] as? URL;
-            //  jitsiViewController?.audioOnly = call.arguments?["audioOnly"] as? Bool;
-            //  jitsiViewController?.audioMuted = call.arguments?["audioMuted"] as? Bool;
-            // jitsiViewController?.videoMuted = call.arguments?["videoMuted"] as? Bool;
             
             let navigationController = UINavigationController(rootViewController: (jitsiViewController)!)
             navigationController.modalPresentationStyle = .fullScreen

--- a/lib/feature_flag/feature_flag_enum.dart
+++ b/lib/feature_flag/feature_flag_enum.dart
@@ -1,0 +1,73 @@
+
+/// Enumeration of all available feature flags
+/// Reflects the official list of Jitsi Meet SDK 2.9.0 feature flags
+/// https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/flags/constants.js
+enum FeatureFlagEnum
+{
+  /// Flag indicating if add-people functionality should be enabled.
+  /// Default: enabled (true).
+  ADD_PEOPLE_ENABLED,
+
+  /// Flag indicating if calendar integration should be enabled.
+  /// Default: enabled (true) on Android, auto-detected on iOS.
+  CALENDAR_ENABLED,
+
+  /// Flag indicating if call integration (CallKit on iOS, ConnectionService on Android)
+  /// should be enabled.
+  /// Default: enabled (true).
+  CALL_INTEGRATION_ENABLED,
+
+  /// Flag indicating if close captions should be enabled.
+  /// Default: enabled (true).
+  CLOSE_CAPTIONS_ENABLED,
+
+  /// Flag indicating if chat should be enabled.
+  /// Default: enabled (true).
+  CHAT_ENABLED,
+
+  /// Flag indicating if invite functionality should be enabled.
+  /// Default: enabled (true).
+  INVITE_ENABLED,
+
+  /// Flag indicating if recording should be enabled in iOS.
+  /// Default: disabled (false).
+  IOS_RECORDING_ENABLED,
+
+  /// Flag indicating if live-streaming should be enabled.
+  /// Default: auto-detected.
+  LIVE_STREAMING_ENABLED,
+
+  /// Flag indicating if displaying the meeting name should be enabled.
+  /// Default: enabled (true).
+  MEETING_NAME_ENABLED,
+
+  /// Flag indicating if the meeting password button should be enabled.
+  /// Note that this flag just decides on the buttton, if a meeting has a password
+  /// set, the password ddialog will still show up.
+  /// Default: enabled (true).
+  MEETING_PASSWORD_ENABLED,
+
+  /// Flag indicating if Picture-in-Picture should be enabled.
+  /// Default: auto-detected.
+  PIP_ENABLED,
+
+  /// Flag indicating if raise hand feature should be enabled.
+  /// Default: enabled.
+  RAISE_HAND_ENABLED,
+
+  /// Flag indicating if recording should be enabled.
+  /// Default: auto-detected.
+  RECORDING_ENABLED,
+
+  /// Flag indicating if tile view feature should be enabled.
+  /// Default: enabled.
+  TILE_VIEW_ENABLED,
+
+  /// Flag indicating if the toolbox should be always be visible
+  /// Default: disabled (false).
+  TOOLBOX_ALWAYS_VISIBLE,
+
+  /// Flag indicating if the welcome page should be enabled.
+  /// Default: disabled (false).
+  WELCOME_PAGE_ENABLED,
+}

--- a/lib/feature_flag/feature_flag_helper.dart
+++ b/lib/feature_flag/feature_flag_helper.dart
@@ -1,0 +1,28 @@
+
+import 'feature_flag_enum.dart';
+
+/// Helper containing the associative map with feature flags and their string values.
+/// Reflects the official list of Jitsi Meet SDK 2.9.0 feature flags
+/// https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/flags/constants.js
+class FeatureFlagHelper
+{
+  static Map<FeatureFlagEnum, String> featureFlags =
+  {
+    FeatureFlagEnum.ADD_PEOPLE_ENABLED : 'add-people.enabled',
+    FeatureFlagEnum.CALENDAR_ENABLED : 'calendar.enabled',
+    FeatureFlagEnum.CALL_INTEGRATION_ENABLED : 'call-integration.enabled',
+    FeatureFlagEnum.CLOSE_CAPTIONS_ENABLED : 'close-captions.enabled',
+    FeatureFlagEnum.CHAT_ENABLED : 'chat.enabled',
+    FeatureFlagEnum.INVITE_ENABLED : 'invite.enabled',
+    FeatureFlagEnum.IOS_RECORDING_ENABLED : 'ios.recording.enabled',
+    FeatureFlagEnum.LIVE_STREAMING_ENABLED : 'live-streaming.enabled',
+    FeatureFlagEnum.MEETING_NAME_ENABLED : 'meeting-name.enabled',
+    FeatureFlagEnum.MEETING_PASSWORD_ENABLED : 'meeting-password.enabled',
+    FeatureFlagEnum.PIP_ENABLED : 'pip.enabled',
+    FeatureFlagEnum.RAISE_HAND_ENABLED : 'raise-hand.enabled',
+    FeatureFlagEnum.RECORDING_ENABLED : 'recording.enabled',
+    FeatureFlagEnum.TILE_VIEW_ENABLED : 'tile-view.enabled',
+    FeatureFlagEnum.TOOLBOX_ALWAYS_VISIBLE : 'toolbox.alwaysVisible',
+    FeatureFlagEnum.WELCOME_PAGE_ENABLED : 'welcomepage.enabled',
+  };
+}

--- a/lib/jitsi_meet.dart
+++ b/lib/jitsi_meet.dart
@@ -102,11 +102,6 @@ class JitsiMeet {
           'audioOnly': options.audioOnly,
           'videoMuted': options.videoMuted,
           'featureFlags': options.getFeatureFlags(),
-//          'pipEnabled': options.pipEnabled,
-//          'addPeopleEnabled': options.addPeopleEnabled,
-//          'calendarEnabled': options.calendarEnabled,
-//          'chatEnabled': options.chatEnabled,
-//          'inviteEnabled': options.inviteEnabled,
           'userDisplayName': options.userDisplayName,
           'userEmail': options.userEmail,
           'iosAppBarRGBAColor': options.iosAppBarRGBAColor,
@@ -226,11 +221,6 @@ class JitsiMeetingOptions
   bool audioMuted;
   bool audioOnly;
   bool videoMuted;
-//  bool pipEnabled;
-//  bool addPeopleEnabled;
-//  bool calendarEnabled;
-//  bool chatEnabled;
-//  bool inviteEnabled;
   String userDisplayName;
   String userEmail;
   String iosAppBarRGBAColor;
@@ -243,9 +233,9 @@ class JitsiMeetingOptions
   {
     Map<String, bool> featureFlagsWithStrings = new HashMap();
 
-    featureFlags.forEach((key, value) =>
+    featureFlags.forEach((key, value)
     {
-      featureFlagsWithStrings[FeatureFlagHelper.featureFlags[key]] = value
+      featureFlagsWithStrings[FeatureFlagHelper.featureFlags[key]] = value;
     });
 
     return featureFlagsWithStrings;
@@ -259,7 +249,6 @@ class JitsiMeetingOptions
 
 /* Not used yet, needs more research
   Bundle colorScheme;
-  Bundle featureFlags;
   String userAvatarURL;
 */
 

--- a/lib/jitsi_meet.dart
+++ b/lib/jitsi_meet.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'jitsi_meeting_listener.dart';
+import 'feature_flag/feature_flag_enum.dart';
+import 'feature_flag/feature_flag_helper.dart';
 import 'room_name_constraint.dart';
 import 'room_name_constraint_type.dart';
 
@@ -98,11 +101,12 @@ class JitsiMeet {
           'audioMuted': options.audioMuted,
           'audioOnly': options.audioOnly,
           'videoMuted': options.videoMuted,
-          'pipEnabled': options.pipEnabled,
-          'addPeopleEnabled': options.addPeopleEnabled,
-          'calendarEnabled': options.calendarEnabled,
-          'chatEnabled': options.chatEnabled,
-          'inviteEnabled': options.inviteEnabled,
+          'featureFlags': options.getFeatureFlags(),
+//          'pipEnabled': options.pipEnabled,
+//          'addPeopleEnabled': options.addPeopleEnabled,
+//          'calendarEnabled': options.calendarEnabled,
+//          'chatEnabled': options.chatEnabled,
+//          'inviteEnabled': options.inviteEnabled,
           'userDisplayName': options.userDisplayName,
           'userEmail': options.userEmail,
           'iosAppBarRGBAColor': options.iosAppBarRGBAColor,
@@ -213,7 +217,8 @@ class JitsiMeetingResponse {
   }
 }
 
-class JitsiMeetingOptions {
+class JitsiMeetingOptions
+{
   String room;
   String serverURL;
   String subject;
@@ -221,18 +226,35 @@ class JitsiMeetingOptions {
   bool audioMuted;
   bool audioOnly;
   bool videoMuted;
-  bool pipEnabled;
-  bool addPeopleEnabled;
-  bool calendarEnabled;
-  bool chatEnabled;
-  bool inviteEnabled;
+//  bool pipEnabled;
+//  bool addPeopleEnabled;
+//  bool calendarEnabled;
+//  bool chatEnabled;
+//  bool inviteEnabled;
   String userDisplayName;
   String userEmail;
   String iosAppBarRGBAColor;
 
+  Map<FeatureFlagEnum, bool> featureFlags = new HashMap();
+
+  /// Get feature flags Map with keys as String instead of Enum
+  /// Useful as an argument sent to the Kotlin/Swift code
+  Map<String, bool> getFeatureFlags()
+  {
+    Map<String, bool> featureFlagsWithStrings = new HashMap();
+
+    featureFlags.forEach((key, value) =>
+    {
+      featureFlagsWithStrings[FeatureFlagHelper.featureFlags[key]] = value
+    });
+
+    return featureFlagsWithStrings;
+  }
+
   @override
-  String toString() {
-    return 'JitsiMeetingOptions{room: $room, serverURL: $serverURL, subject: $subject, token: $token, audioMuted: $audioMuted, audioOnly: $audioOnly, videoMuted: $videoMuted, pipEnabled: $pipEnabled, addPeopleEnabled: $addPeopleEnabled, calendarEnabled: $calendarEnabled, chatEnabled: $chatEnabled, inviteEnabled: $inviteEnabled userDisplayName: $userDisplayName, userEmail: $userEmail, iosAppBarRGBAColor :$iosAppBarRGBAColor }';
+  String toString()
+  {
+    return 'JitsiMeetingOptions{room: $room, serverURL: $serverURL, subject: $subject, token: $token, audioMuted: $audioMuted, audioOnly: $audioOnly, videoMuted: $videoMuted, userDisplayName: $userDisplayName, userEmail: $userEmail, iosAppBarRGBAColor :$iosAppBarRGBAColor, featureFlags: $featureFlags }';
   }
 
 /* Not used yet, needs more research


### PR DESCRIPTION
Improved implementation of feature flags. 
**TLDR : All feature flags are now available through the plugin.**

#### Modifications

- [X] Created a list of flags based on [Jitsi Meet constants](https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/flags/constants.js), as an `Enum`
- [X] Added flags descriptions (in comments) and values (in a `Map`)
- [X] Removed `.setWelcomePageEnabled(false)` from Kotlin code as it uses feature flags under the hood ([see here](https://github.com/jitsi/jitsi-meet/blob/master/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetConferenceOptions.java#L234))
- [X] Modified Android/Kotlin code to get and use the `Map` of feature flags instead of "static" fields
- [X] Modified iOS/Swift code to get and use the `Map` of feature flags instead of "static" fields
- [X] Modified `example` app to show how to use flags
- [X] Updated README with informations about feature flags

#### Why ?

- We now have **only an `Enum` and a `Map` to modify if new feature flags are added** in Jitsi Meet SDK, we don't need to add attributes/fields and everything
- Meeting options and feature flags are a bit more separated (no longer need one field in `JitsiMeetOptions` for each flag)
- It's **more convenient to use** (developers just fill a map with flags they need to modify)
- It's safer to use (thanks to the `Enum` and `Map`)
- If **no flags are provided, default values from the SDK will be used** (we no longer need to put something with `flagname ? : false` and set an arbitrary `true` or `false` default setting

#### Reviews

I tested that modification under virtual devices, both on Android and iOS. If you want to test it yourself, go on, I'd be glad to get some feedback, and even maybe improvements 😉 
