### PR TITLE
Add pass through for the jwt token option on iOS

### DIFF
--- a/ios/Classes/JitsiViewController.swift
+++ b/ios/Classes/JitsiViewController.swift
@@ -15,6 +15,7 @@ class JitsiViewController: UIViewController {
     var audioOnly:Bool? = false
     var audioMuted: Bool? = false
     var videoMuted: Bool? = false
+    var token:String? = nil
     var featureFlags: Dictionary<String, Bool>? = Dictionary();
     var appBarColor: UIColor? = UIColor(hex: "#00000000")
     
@@ -70,6 +71,7 @@ class JitsiViewController: UIViewController {
             builder.audioOnly = self.audioOnly ?? false
             builder.audioMuted = self.audioMuted ?? false
             builder.videoMuted = self.videoMuted ?? false
+            builder.token = self.token
             
             self.featureFlags?.forEach{ key,value in
                 builder.setFeatureFlag(key, withValue: value);

--- a/ios/Classes/SwiftJitsiMeetPlugin.swift
+++ b/ios/Classes/SwiftJitsiMeetPlugin.swift
@@ -51,12 +51,14 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                     let subject = myArgs["subject"] as? String
                     let displayName = myArgs["userDisplayName"] as? String
                     let email = myArgs["userEmail"] as? String
+                    let token = myArgs["token"] as? String
                     let appBarColor = myArgs["iosAppBarRGBAColor"] as? String
                     
                     jitsiViewController?.roomName = roomName;
                     jitsiViewController?.subject = subject;
                     jitsiViewController?.jistiMeetUserInfo.displayName = displayName;
-                    jitsiViewController?.jistiMeetUserInfo.email = email;                    
+                    jitsiViewController?.jistiMeetUserInfo.email = email;
+                    jitsiViewController?.token = token;
                  
                     jitsiViewController?.appBarColor = UIColor(hex: appBarColor ??  "#00000000")
                     


### PR DESCRIPTION
Our project require connection to a custom Jitsi server using a jwt token. This was working on Android, but the token was not being passed to the JitsiMeet SDK on iOS.

Test and working on iOS.