### PR TITLE
Remove Navigation bar for both Android and iOS

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
             android:launchMode="singleTask"
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             android:windowSoftInputMode="adjustResize">
         </activity>
     </application>

--- a/ios/Classes/JitsiViewController.swift
+++ b/ios/Classes/JitsiViewController.swift
@@ -17,12 +17,12 @@ class JitsiViewController: UIViewController {
     var videoMuted: Bool? = false
     var token:String? = nil
     var featureFlags: Dictionary<String, Bool>? = Dictionary();
-    var appBarColor: UIColor? = UIColor(hex: "#00000000")
+    
     
     var jistiMeetUserInfo = JitsiMeetUserInfo()
     
     override func loadView() {
-        self.navigationController?.navigationBar.barTintColor = self.appBarColor
+        
         super.loadView()
     }
     

--- a/ios/Classes/SwiftJitsiMeetPlugin.swift
+++ b/ios/Classes/SwiftJitsiMeetPlugin.swift
@@ -55,7 +55,7 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                     let displayName = myArgs["userDisplayName"] as? String
                     let email = myArgs["userEmail"] as? String
                     let token = myArgs["token"] as? String
-                    let appBarColor = myArgs["iosAppBarRGBAColor"] as? String
+                    
                     
                     self.jitsiViewController?.roomName = roomName;
                     self.jitsiViewController?.subject = subject;
@@ -63,7 +63,7 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                     self.jitsiViewController?.jistiMeetUserInfo.email = email;
                     self.jitsiViewController?.token = token;
                  
-                    self.jitsiViewController?.appBarColor = UIColor(hex: appBarColor ??  "#00000000")
+                    
                     
                     //                    let avatar = myArgs["userAvatarURL"] as? String,
                     //                    let avatarURL  = URL(string: avatar)
@@ -97,6 +97,7 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             }
             
             let navigationController = UINavigationController(rootViewController: (self.jitsiViewController)!)
+            navigationController.setNavigationBarHidden(true, animated: false)
             navigationController.modalPresentationStyle = .fullScreen
             navigationController.navigationBar.barTintColor = UIColor.black
             self.uiVC.present(navigationController, animated: true)

--- a/lib/jitsi_meet.dart
+++ b/lib/jitsi_meet.dart
@@ -227,7 +227,6 @@ class JitsiMeetingOptions
   bool videoMuted;
   String userDisplayName;
   String userEmail;
-  String iosAppBarRGBAColor;
 
   Map<FeatureFlagEnum, bool> featureFlags = new HashMap();
 
@@ -248,7 +247,7 @@ class JitsiMeetingOptions
   @override
   String toString()
   {
-    return 'JitsiMeetingOptions{room: $room, serverURL: $serverURL, subject: $subject, token: $token, audioMuted: $audioMuted, audioOnly: $audioOnly, videoMuted: $videoMuted, userDisplayName: $userDisplayName, userEmail: $userEmail, iosAppBarRGBAColor :$iosAppBarRGBAColor, featureFlags: $featureFlags }';
+    return 'JitsiMeetingOptions{room: $room, serverURL: $serverURL, subject: $subject, token: $token, audioMuted: $audioMuted, audioOnly: $audioOnly, videoMuted: $videoMuted, userDisplayName: $userDisplayName, userEmail: $userEmail, featureFlags: $featureFlags }';
   }
 
 /* Not used yet, needs more research


### PR DESCRIPTION
Provide an immersive experience on both platform...

Suited for #64 

1) Removed navigation bar which is briefly visibly during room join and creation.

2) In iOS removed iosAppBarRGBAColor feature, as it wont make any sense if there is no navbar.
