### PR TITLE
Add .iml files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .atom/
 .idea/
 .vscode/
+**.iml
 
 .packages
 .pub/


### PR DESCRIPTION
.iml should not be checked into Version Control

Tip: Use `git rm --cached jitsi_meet.iml` to stop tracking the file so that it isn't uploaded the next time