### PR TITLE
iOS - Return Future for JoinMeeting call

### DIFF
--- a/ios/Classes/SwiftJitsiMeetPlugin.swift
+++ b/ios/Classes/SwiftJitsiMeetPlugin.swift
@@ -101,10 +101,8 @@ public class SwiftJitsiMeetPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             navigationController.modalPresentationStyle = .fullScreen
             navigationController.navigationBar.barTintColor = UIColor.black
             self.uiVC.present(navigationController, animated: true)
+            result(nil)
             
-            //self.uiVC.modalPresentationStyle = .fullScreen
-            //self.uiVC.present(jitsiViewController!, animated: true, completion: nil)
-            //print("OPEN JITSI MEET CALLED")
         }else if (call.method == "closeMeeting") {
             
             


### PR DESCRIPTION
Will return future on JitsiMeet.joinMeeting() call - > `JitsiMeetingResponse{isSuccess: true, message: null, error: null}`

Resolves #99 
