### PR TITLE
Callback for PIP mode

### DIFF
--- a/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetEventStreamHandler.kt
+++ b/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetEventStreamHandler.kt
@@ -43,4 +43,20 @@ class JitsiMeetEventStreamHandler private constructor(): EventChannel.StreamHand
         eventSink?.success(data)
     }
 
+    fun onPictureInPictureWillEnter() {
+        Log.d(JITSI_PLUGIN_TAG, "JitsiMeetEventStreamHandler.onPictureInPictureWillEnter")
+        var data : HashMap<String, String>
+                = HashMap<String, String> ()
+        data?.put("event", "onPictureInPictureWillEnter")
+        eventSink?.success(data)
+    }
+
+    fun onPictureInPictureTerminated() {
+        Log.d(JITSI_PLUGIN_TAG, "JitsiMeetEventStreamHandler.onPictureInPictureTerminated")
+        var data : HashMap<String, String>
+                = HashMap<String, String> ()
+        data?.put("event", "onPictureInPictureTerminated")
+        eventSink?.success(data)
+    }
+
 }

--- a/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPluginActivity.kt
+++ b/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPluginActivity.kt
@@ -36,6 +36,13 @@ class JitsiMeetPluginActivity : JitsiMeetActivity() {
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
 
+        if (isInPictureInPictureMode){
+            JitsiMeetEventStreamHandler.instance.onPictureInPictureWillEnter()
+        }
+        else {
+            JitsiMeetEventStreamHandler.instance.onPictureInPictureTerminated()
+        }
+
         if (isInPictureInPictureMode == false && onStopCalled) {
             // Picture-in-Picture mode has been closed, we can (should !) end the call
             getJitsiView().leave()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -259,13 +259,11 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _onPictureInPictureWillEnter({message}) {
-    debugPrint(
-        "_onPictureInPictureWillEnter broadcasted with message: $message");
+    debugPrint("_onPictureInPictureWillEnter broadcasted with message: $message");
   }
 
   void _onPictureInPictureTerminated({message}) {
-    debugPrint(
-        "_onPictureInPictureTerminated broadcasted with message: $message");
+    debugPrint("_onPictureInPictureTerminated broadcasted with message: $message");
   }
 
   _onError(error) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,8 @@ class _MyAppState extends State<MyApp> {
         onConferenceWillJoin: _onConferenceWillJoin,
         onConferenceJoined: _onConferenceJoined,
         onConferenceTerminated: _onConferenceTerminated,
+        onPictureInPictureWillEnter: _onPictureInPictureWillEnter,
+        onPictureInPictureTerminated: _onPictureInPictureTerminated,
         onError: _onError));
   }
 
@@ -254,6 +256,16 @@ class _MyAppState extends State<MyApp> {
 
   void _onConferenceTerminated({message}) {
     debugPrint("_onConferenceTerminated broadcasted with message: $message");
+  }
+
+  void _onPictureInPictureWillEnter({message}) {
+    debugPrint(
+        "_onPictureInPictureWillEnter broadcasted with message: $message");
+  }
+
+  void _onPictureInPictureTerminated({message}) {
+    debugPrint(
+        "_onPictureInPictureTerminated broadcasted with message: $message");
   }
 
   _onError(error) {

--- a/ios/Classes/JitsiViewController.swift
+++ b/ios/Classes/JitsiViewController.swift
@@ -136,38 +136,20 @@ extension JitsiViewController: JitsiMeetViewDelegate {
     }
     
     func enterPicture(inPicture data: [AnyHashable : Any]!) {
-        //        print("CONFERENCE PIP")
+        //        print("CONFERENCE PIP IN")
+        var mutatedData = data
+        mutatedData?.updateValue("onPictureInPictureWillEnter", forKey: "event")
+        self.eventSink?(mutatedData)
         DispatchQueue.main.async {
             self.pipViewCoordinator?.enterPictureInPicture()
         }
     }
-}
-
-
-extension UIColor {
-    public convenience init?(hex: String) {
-        let r, g, b, a: CGFloat
-
-        if hex.hasPrefix("#") {
-            let start = hex.index(hex.startIndex, offsetBy: 1)
-            let hexColor = String(hex[start...])
-
-            if hexColor.count == 8 {
-                let scanner = Scanner(string: hexColor)
-                var hexNumber: UInt64 = 0
-
-                if scanner.scanHexInt64(&hexNumber) {
-                    r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
-                    g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
-                    b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
-                    a = CGFloat(hexNumber & 0x000000ff) / 255
-
-                    self.init(red: r, green: g, blue: b, alpha: a)
-                    return
-                }
-            }
-        }
-
-        return nil
+    
+    func exitPictureInPicture() {
+        //        print("CONFERENCE PIP OUT")
+        var mutatedData : [AnyHashable : Any]
+        mutatedData = ["event":"onPictureInPictureTerminated"]
+        self.eventSink?(mutatedData)
     }
 }
+

--- a/lib/jitsi_meet.dart
+++ b/lib/jitsi_meet.dart
@@ -156,6 +156,14 @@ class JitsiMeet {
           if (listener.onConferenceTerminated != null)
             listener.onConferenceTerminated(message: message);
           break;
+        case "onPictureInPictureWillEnter":
+          if (listener.onPictureInPictureWillEnter != null)
+            listener.onPictureInPictureWillEnter(message: message);
+          break;
+        case "onPictureInPictureTerminated":
+          if (listener.onPictureInPictureTerminated != null)
+            listener.onPictureInPictureTerminated(message: message);
+          break;
       }
     });
   }
@@ -180,6 +188,14 @@ class JitsiMeet {
 
           // Remove the listener from the map of _perMeetingListeners on terminate
           _perMeetingListeners.remove(listener);
+          break;
+        case "onPictureInPictureWillEnter":
+          if (listener.onPictureInPictureWillEnter != null)
+            listener.onPictureInPictureWillEnter(message: message);
+          break;
+        case "onPictureInPictureTerminated":
+          if (listener.onPictureInPictureTerminated != null)
+            listener.onPictureInPictureTerminated(message: message);
           break;
       }
     }

--- a/lib/jitsi_meeting_listener.dart
+++ b/lib/jitsi_meeting_listener.dart
@@ -3,11 +3,15 @@ class JitsiMeetingListener {
   final Function({Map<dynamic, dynamic> message}) onConferenceWillJoin;
   final Function({Map<dynamic, dynamic> message}) onConferenceJoined;
   final Function({Map<dynamic, dynamic> message}) onConferenceTerminated;
+  final Function({Map<dynamic, dynamic> message}) onPictureInPictureWillEnter;
+  final Function({Map<dynamic, dynamic> message}) onPictureInPictureTerminated;
   final Function(dynamic error) onError;
 
   JitsiMeetingListener(
       {this.onConferenceWillJoin,
       this.onConferenceJoined,
       this.onConferenceTerminated,
+      this.onPictureInPictureWillEnter,
+      this.onPictureInPictureTerminated,
       this.onError});
 }


### PR DESCRIPTION
Listener added to capture Jitsi's entry and exit from PIP mode
Addresses this query -> #76 

Example added to main.dart file

Snippet

Add Listener
```

JitsiMeet.addListener(JitsiMeetingListener(
        onConferenceWillJoin: _onConferenceWillJoin,
        onConferenceJoined: _onConferenceJoined,
        onConferenceTerminated: _onConferenceTerminated,
        onPictureInPictureWillEnter: _onPictureInPictureWillEnter,
        onPictureInPictureTerminated: _onPictureInPictureTerminated,
        onError: _onError));
```

Then
```

_onPictureInPictureWillEnter({message}) {
    print("_onPictureInPictureWillEnter");
  }

  _onPictureInPictureTerminated({message}) {
    print("_onPictureInPictureTerminated");
  }
```