### PR TITLE
Migrated to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+* Migrated to null safety
+* Changed `RaisedButton` to `ElevationButton` in example
+
 ## 2.0.0
 * BREAKING: Update feature flags to be a class instead of a map.
 * Added more feature flags.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,8 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:jitsi_meet/feature_flag/feature_flag.dart';
 import 'package:jitsi_meet/jitsi_meet.dart';
 import 'package:jitsi_meet/jitsi_meeting_listener.dart';
-import 'package:jitsi_meet/room_name_constraint.dart';
-import 'package:jitsi_meet/room_name_constraint_type.dart';
 
 void main() => runApp(MyApp());
 
@@ -141,7 +139,7 @@ class _MyAppState extends State<MyApp> {
                 SizedBox(
                   height: 64.0,
                   width: double.maxFinite,
-                  child: RaisedButton(
+                  child: ElevatedButton(
                     onPressed: () {
                       _joinMeeting();
                     },
@@ -149,7 +147,7 @@ class _MyAppState extends State<MyApp> {
                       "Join Meeting",
                       style: TextStyle(color: Colors.white),
                     ),
-                    color: Colors.blue,
+                    style: ElevatedButton.styleFrom(primary: Colors.blue),
                   ),
                 ),
                 SizedBox(
@@ -238,18 +236,6 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  static final Map<RoomNameConstraintType, RoomNameConstraint>
-      customContraints = {
-    RoomNameConstraintType.MAX_LENGTH: new RoomNameConstraint((value) {
-      return value.trim().length <= 50;
-    }, "Maximum room name length should be 30."),
-    RoomNameConstraintType.FORBIDDEN_CHARS: new RoomNameConstraint((value) {
-      return RegExp(r"[$€£]+", caseSensitive: false, multiLine: false)
-              .hasMatch(value) ==
-          false;
-    }, "Currencies characters aren't allowed in room names."),
-  };
-
   void _onConferenceWillJoin({message}) {
     debugPrint("_onConferenceWillJoin broadcasted with message: $message");
   }
@@ -263,11 +249,13 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _onPictureInPictureWillEnter({message}) {
-    debugPrint("_onPictureInPictureWillEnter broadcasted with message: $message");
+    debugPrint(
+        "_onPictureInPictureWillEnter broadcasted with message: $message");
   }
 
   void _onPictureInPictureTerminated({message}) {
-    debugPrint("_onPictureInPictureTerminated broadcasted with message: $message");
+    debugPrint(
+        "_onPictureInPictureTerminated broadcasted with message: $message");
   }
 
   _onError(error) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -157,5 +157,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +73,28 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,56 +106,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.10.0 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.10.0"

--- a/lib/feature_flag/feature_flag.dart
+++ b/lib/feature_flag/feature_flag.dart
@@ -4,29 +4,29 @@ import 'feature_flag_enum.dart';
 import 'feature_flag_helper.dart';
 
 class FeatureFlag {
-  bool addPeopleEnabled;
-  bool calendarEnabled;
-  bool callIntegrationEnabled;
-  bool closeCaptionsEnabled;
-  bool conferenceTimerEnabled;
-  bool chatEnabled;
-  bool inviteEnabled;
-  bool iOSRecordingEnabled;
-  bool kickOutEnabled;
-  bool liveStreamingEnabled;
-  bool meetingNameEnabled;
-  bool meetingPasswordEnabled;
-  bool pipEnabled;
-  bool raiseHandEnabled;
-  bool recordingEnabled;
-  int _resolution;
-  bool serverURLChangeEnabled;
-  bool tileViewEnabled;
-  bool toolboxAlwaysVisible;
-  bool videoShareButtonEnabled;
-  bool welcomePageEnabled;
+  bool? addPeopleEnabled;
+  bool? calendarEnabled;
+  bool? callIntegrationEnabled;
+  bool? closeCaptionsEnabled;
+  bool? conferenceTimerEnabled;
+  bool? chatEnabled;
+  bool? inviteEnabled;
+  bool? iOSRecordingEnabled;
+  bool? kickOutEnabled;
+  bool? liveStreamingEnabled;
+  bool? meetingNameEnabled;
+  bool? meetingPasswordEnabled;
+  bool? pipEnabled;
+  bool? raiseHandEnabled;
+  bool? recordingEnabled;
+  int? _resolution;
+  bool? serverURLChangeEnabled;
+  bool? tileViewEnabled;
+  bool? toolboxAlwaysVisible;
+  bool? videoShareButtonEnabled;
+  bool? welcomePageEnabled;
 
-  int get resoulution {
+  int? get resoulution {
     return _resolution;
   }
 
@@ -43,8 +43,8 @@ class FeatureFlag {
     _resolution = videoResolution;
   }
 
-  Map<String, dynamic> allFeatureFlags() {
-    Map<String, dynamic> featureFlags = new HashMap();
+  Map<String?, dynamic> allFeatureFlags() {
+    Map<String?, dynamic> featureFlags = new HashMap();
 
     if (addPeopleEnabled != null)
       featureFlags[FeatureFlagHelper

--- a/lib/jitsi_meet.dart
+++ b/lib/jitsi_meet.dart
@@ -21,7 +21,7 @@ class JitsiMeet {
   static final Map<RoomNameConstraintType, RoomNameConstraint>
       defaultRoomNameConstraints = {
     RoomNameConstraintType.MIN_LENGTH: new RoomNameConstraint((value) {
-      return value.trim().length >= 3;
+      return value!.trim().length >= 3;
     }, "Minimum room length is 3"),
 
 //    RoomNameConstraintType.MAX_LENGTH : new RoomNameConstraint(
@@ -30,7 +30,7 @@ class JitsiMeet {
 
     RoomNameConstraintType.ALLOWED_CHARS: new RoomNameConstraint((value) {
       return RegExp(r"^[a-zA-Z0-9-_]+$", caseSensitive: false, multiLine: false)
-          .hasMatch(value);
+          .hasMatch(value!);
     }, "Only alphanumeric, dash, and underscore chars allowed"),
 
 //    RoomNameConstraintType.FORBIDDEN_CHARS : new RoomNameConstraint(
@@ -42,12 +42,11 @@ class JitsiMeet {
   /// A JitsiMeetingListener can be attached to this meeting that will automatically
   /// be removed when the meeting has ended
   static Future<JitsiMeetingResponse> joinMeeting(JitsiMeetingOptions options,
-      {JitsiMeetingListener listener,
-      Map<RoomNameConstraintType, RoomNameConstraint>
+      {JitsiMeetingListener? listener,
+      Map<RoomNameConstraintType, RoomNameConstraint>?
           roomNameConstraints}) async {
-    assert(options != null, "options are null");
     assert(options.room != null, "room is null");
-    assert(options.room.trim().isNotEmpty, "room is empty");
+    assert(options.room!.trim().isNotEmpty, "room is empty");
 
     // If no constraints given, take default ones
     // (To avoid using constraint, just give an empty Map)
@@ -66,7 +65,7 @@ class JitsiMeet {
 
     // Validate serverURL is absolute if it is not null or empty
     if (options.serverURL?.isNotEmpty ?? false) {
-      assert(Uri.parse(options.serverURL).isAbsolute,
+      assert(Uri.parse(options.serverURL!).isAbsolute,
           "URL must be of the format <scheme>://<host>[/path], like https://someHost.com");
     }
 
@@ -75,9 +74,9 @@ class JitsiMeet {
       String serverURL = options.serverURL ?? "https://meet.jit.si";
       String key;
       if (serverURL.endsWith("/")) {
-        key = serverURL + options.room;
+        key = serverURL + options.room!;
       } else {
-        key = serverURL + "/" + options.room;
+        key = serverURL + "/" + options.room!;
       }
 
       _perMeetingListeners.update(key, (oldListener) => listener,
@@ -119,10 +118,10 @@ class JitsiMeet {
       }, onError: (dynamic error) {
         debugPrint('Jitsi Meet broadcast error: $error');
         _listeners.forEach((listener) {
-          if (listener.onError != null) listener.onError(error);
+          if (listener.onError != null) listener.onError!(error);
         });
         _perMeetingListeners.forEach((key, listener) {
-          if (listener.onError != null) listener.onError(error);
+          if (listener.onError != null) listener.onError!(error);
         });
       });
       _hasInitialized = true;
@@ -146,23 +145,23 @@ class JitsiMeet {
       switch (message['event']) {
         case "onConferenceWillJoin":
           if (listener.onConferenceWillJoin != null)
-            listener.onConferenceWillJoin(message: message);
+            listener.onConferenceWillJoin!(message: message);
           break;
         case "onConferenceJoined":
           if (listener.onConferenceJoined != null)
-            listener.onConferenceJoined(message: message);
+            listener.onConferenceJoined!(message: message);
           break;
         case "onConferenceTerminated":
           if (listener.onConferenceTerminated != null)
-            listener.onConferenceTerminated(message: message);
+            listener.onConferenceTerminated!(message: message);
           break;
         case "onPictureInPictureWillEnter":
           if (listener.onPictureInPictureWillEnter != null)
-            listener.onPictureInPictureWillEnter(message: message);
+            listener.onPictureInPictureWillEnter!(message: message);
           break;
         case "onPictureInPictureTerminated":
           if (listener.onPictureInPictureTerminated != null)
-            listener.onPictureInPictureTerminated(message: message);
+            listener.onPictureInPictureTerminated!(message: message);
           break;
       }
     });
@@ -170,32 +169,32 @@ class JitsiMeet {
 
   /// Sends a broadcast to per meeting listeners added during joinMeeting
   static void _broadcastToPerMeetingListeners(message) {
-    String url = message['url'];
-    final listener = _perMeetingListeners[url];
+    String? url = message['url'];
+    final listener = _perMeetingListeners[url!];
     if (listener != null) {
       switch (message['event']) {
         case "onConferenceWillJoin":
           if (listener.onConferenceWillJoin != null)
-            listener.onConferenceWillJoin(message: message);
+            listener.onConferenceWillJoin!(message: message);
           break;
         case "onConferenceJoined":
           if (listener.onConferenceJoined != null)
-            listener.onConferenceJoined(message: message);
+            listener.onConferenceJoined!(message: message);
           break;
         case "onConferenceTerminated":
           if (listener.onConferenceTerminated != null)
-            listener.onConferenceTerminated(message: message);
+            listener.onConferenceTerminated!(message: message);
 
           // Remove the listener from the map of _perMeetingListeners on terminate
           _perMeetingListeners.remove(listener);
           break;
         case "onPictureInPictureWillEnter":
           if (listener.onPictureInPictureWillEnter != null)
-            listener.onPictureInPictureWillEnter(message: message);
+            listener.onPictureInPictureWillEnter!(message: message);
           break;
         case "onPictureInPictureTerminated":
           if (listener.onPictureInPictureTerminated != null)
-            listener.onPictureInPictureTerminated(message: message);
+            listener.onPictureInPictureTerminated!(message: message);
           break;
       }
     }
@@ -213,8 +212,8 @@ class JitsiMeet {
 }
 
 class JitsiMeetingResponse {
-  final bool isSuccess;
-  final String message;
+  final bool? isSuccess;
+  final String? message;
   final dynamic error;
 
   JitsiMeetingResponse({this.isSuccess, this.message, this.error});
@@ -226,22 +225,22 @@ class JitsiMeetingResponse {
 }
 
 class JitsiMeetingOptions {
-  String room;
-  String serverURL;
-  String subject;
-  String token;
-  bool audioMuted;
-  bool audioOnly;
-  bool videoMuted;
-  String userDisplayName;
-  String userEmail;
-  String userAvatarURL;
-  FeatureFlag featureFlag;
+  String? room;
+  String? serverURL;
+  String? subject;
+  String? token;
+  bool? audioMuted;
+  bool? audioOnly;
+  bool? videoMuted;
+  String? userDisplayName;
+  String? userEmail;
+  String? userAvatarURL;
+  FeatureFlag? featureFlag;
 
   /// Get feature flags Map with keys as String instead of Enum
   /// Useful as an argument sent to the Kotlin/Swift code
-  Map<String, dynamic> getFeatureFlags() =>
-      (featureFlag != null) ? featureFlag.allFeatureFlags() : new HashMap();
+  Map<String?, dynamic> getFeatureFlags() =>
+      (featureFlag != null) ? featureFlag!.allFeatureFlags() : new HashMap();
 
   @override
   String toString() {

--- a/lib/jitsi_meeting_listener.dart
+++ b/lib/jitsi_meeting_listener.dart
@@ -1,11 +1,11 @@
 /// Class holding the callback functions for conference events
 class JitsiMeetingListener {
-  final Function({Map<dynamic, dynamic> message}) onConferenceWillJoin;
-  final Function({Map<dynamic, dynamic> message}) onConferenceJoined;
-  final Function({Map<dynamic, dynamic> message}) onConferenceTerminated;
-  final Function({Map<dynamic, dynamic> message}) onPictureInPictureWillEnter;
-  final Function({Map<dynamic, dynamic> message}) onPictureInPictureTerminated;
-  final Function(dynamic error) onError;
+  final Function({Map<dynamic, dynamic>? message})? onConferenceWillJoin;
+  final Function({Map<dynamic, dynamic>? message})? onConferenceJoined;
+  final Function({Map<dynamic, dynamic>? message})? onConferenceTerminated;
+  final Function({Map<dynamic, dynamic>? message})? onPictureInPictureWillEnter;
+  final Function({Map<dynamic, dynamic>? message})? onPictureInPictureTerminated;
+  final Function(dynamic error)? onError;
 
   JitsiMeetingListener(
       {this.onConferenceWillJoin,

--- a/lib/room_name_constraint.dart
+++ b/lib/room_name_constraint.dart
@@ -1,17 +1,17 @@
 class RoomNameConstraint {
-  Function(String) _checkFunction;
-  String _constraintMessage;
+  late Function(String?) _checkFunction;
+  String? _constraintMessage;
 
-  RoomNameConstraint(Function(String) checkFunction, String constraintMessage) {
+  RoomNameConstraint(Function(String?) checkFunction, String constraintMessage) {
     _checkFunction = checkFunction;
     _constraintMessage = constraintMessage;
   }
 
-  bool checkConstraint(String value) {
+  bool checkConstraint(String? value) {
     return _checkFunction(value);
   }
 
-  String getMessage() {
+  String? getMessage() {
     return _constraintMessage;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,56 +92,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.10.0 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.10.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -143,5 +143,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/gunschu/jitsi_meet
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.10.0 <2.0.0"
+  flutter: ">=1.10.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,15 +15,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The androidPackage and pluginClass identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -31,32 +23,3 @@ flutter:
         pluginClass: JitsiMeetPlugin
       ios:
         pluginClass: JitsiMeetPlugin
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 homepage: https://github.com/gunschu/jitsi_meet
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.10.0 <2.0.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jitsi_meet
 description: Jitsi Meet Plugin - A plugin for integrating open source Jitsi Meet API in flutter. Jitsi Meet is secure, fully featured and allows completely free video conferencing made with https://jitsi.org, a collection of open source projects
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/gunschu/jitsi_meet
 
 environment:


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to `2.12.0+`
* Run `dart migrate` on existing code to remove unsafe nulls (for the package & example)
* Add a new version (`3.0.0`) to the changelog (as [recommended](https://dart.dev/null-safety/migration-guide#package-version))
* Changed `RaisedButton` to `ElevationButton` in example
* Removed analyzer warnings

Please check everything twice!

## Testing
- [x] Tested it manually on a Android emulator 

### Related tickets
Closes #197 