### PR TITLE
Update Jitsi Meet SDK version to 3.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Jitsi Meet from https://github.com/jitsi/jitsi-maven-repository/tree/master/releases/org/jitsi/react/jitsi-meet-sdk
-    implementation ('org.jitsi.react:jitsi-meet-sdk:2.11.0') { transitive = true }
+    implementation ('org.jitsi.react:jitsi-meet-sdk:3.2.0') { transitive = true }
 }

--- a/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPluginActivity.kt
+++ b/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPluginActivity.kt
@@ -69,19 +69,19 @@ class JitsiMeetPluginActivity : JitsiMeetActivity() {
         registerReceiver(myReceiver, IntentFilter(JITSI_MEETING_CLOSE))
     }
 
-    override fun onConferenceWillJoin(data: MutableMap<String, Any>?) {
+    override fun onConferenceWillJoin(data: HashMap<String, Any>) {
         Log.d(JITSI_PLUGIN_TAG, String.format("JitsiMeetPluginActivity.onConferenceWillJoin: %s", data))
         JitsiMeetEventStreamHandler.instance.onConferenceWillJoin(data)
         super.onConferenceWillJoin(data)
     }
 
-    override fun onConferenceJoined(data: MutableMap<String, Any>?) {
+    override fun onConferenceJoined(data: HashMap<String, Any>) {
         Log.d(JITSI_PLUGIN_TAG, String.format("JitsiMeetPluginActivity.onConferenceJoined: %s", data))
         JitsiMeetEventStreamHandler.instance.onConferenceJoined(data)
         super.onConferenceJoined(data)
     }
 
-    override fun onConferenceTerminated(data: MutableMap<String, Any>?) {
+    override fun onConferenceTerminated(data: HashMap<String, Any>) {
 
         Log.d(JITSI_PLUGIN_TAG, String.format("JitsiMeetPluginActivity.onConferenceTerminated: %s", data))
         JitsiMeetEventStreamHandler.instance.onConferenceTerminated(data)


### PR DESCRIPTION
Flutter apps using the `jitsi_meet` plugin occasionally crash on Android due to missing null checks in the underlying Jitsi Meet SDK (#187). This has been discussed extensively in the Jitsi Meet SDK project (https://github.com/jitsi/jitsi-meet/pull/7961) and [was fixed a while ago](https://github.com/jitsi/jitsi-meet/pull/7963#issuecomment-803927847) (presumably in SDK version 3.0.0).

This PR updates the version of the underlying Jitsi Meet SDK to 3.2.0 to include the missing null checks in the Flutter `jitsi_meet` plugin. The necessary code changes are limited to 3 overridden methods of class `JitsiMeetActivity`, whose parameter types changed.

While these changes work for me, a second pair of eyes verifying the fix would be appreciated.