### PR TITLE
doc: proguard-rules.pro broken link updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ buildTypes {
 ```
 
 Then add a file in the same directory called proguard-rules.pro. See the example 
-app's [proguard-rules.pro](example/android/app/proguard-rules.pro) file to know what to paste in.
+app's [proguard-rules.pro](https://github.com/gunschu/jitsi_meet/blob/feat/3.3.0-feature-flags/jitsi_meet/example/android/app/proguard-rules.pro) file to know what to paste in.
 
 *Note*  
 If you do not create the proguard-rules.pro file, then your app will 


### PR DESCRIPTION


### Description
<!-- Describe the changes you are proposing. Keep PRs small and addressing one issue/feature at a time. -->
proguard-rules.pro link is broken in the official main documentation page.
Link to see the example codes of what actually to paste inside proguard-rules.pro was expired. The link has been updated with the latest one which redirects users to the actual example of proguard-files.pro, so that users of the jitsi_meet package can have an idea of what actually to paste inside newly created proguard-files.pro

### Type of change, choose all that apply. (Put an 'x' in the boxes)
* [x] breaking
* [x] fix
* [ ] feature
* [x] docs
* [ ] ci
* [ ] tests
* [ ] chore (e.g. upgrade of dependencies)

### Test artifacts
Since we do not yet have automated testing please include the following to speed up the review process.
* [x] Video or screenshots of the functionality, bug fix, or regression testing: 
 
![jitsimeet contribute](https://user-images.githubusercontent.com/56621935/117559241-58266080-b0a3-11eb-97e7-f2541767d62d.png)

* [x] Environments tested in (device, version, etc): 

### Have you updated documentation?
* [x] yes
* [ ] no
