### PR TITLE
Fixes touch events on Jitsi view to be also received by the Flutter screen behind

### DIFF
--- a/jitsi_meet/ios/Classes/JitsiViewController.swift
+++ b/jitsi_meet/ios/Classes/JitsiViewController.swift
@@ -53,6 +53,12 @@ class JitsiViewController: UIViewController {
         let rect = CGRect(origin: CGPoint.zero, size: size)
         pipViewCoordinator?.resetBounds(bounds: rect)
     }
+
+    // This is needed to avoid the Flutter view behind it, to be hit by touch events.
+    // See: 
+    // https://github.com/flutter/flutter/issues/14720
+    // https://github.com/flutter/flutter/issues/35784#issuecomment-516243057
+    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {}
     
     func openJitsiMeet() {
         cleanUp()


### PR DESCRIPTION
### Description
This is a fix to avoid touch events made on the Jitsi screen to also be received by the Flutter screen behind it.
This issue only occurs on iOS and it's mentioned here: https://github.com/flutter/flutter/issues/14720 and also here: https://github.com/flutter/flutter/issues/35784#issuecomment-516243057

### Type of change, choose all that apply. (Put an 'x' in the boxes)
* [ ] breaking
* [x] fix
* [ ] feature
* [ ] docs
* [ ] ci
* [ ] tests
* [ ] chore (e.g. upgrade of dependencies)

### Test artifacts
Since we do not yet have automated testing please include the following to speed up the review process.
* [ ] Video or screenshots of the functionality, bug fix, or regression testing: 
* [ ] Environments tested in (device, version, etc): 

### Have you updated documentation?
* [ ] yes
* [x] no
