### PR TITLE
Error Solved- Type mismatch: inferred type is Activity? but Activity …

### DIFF
--- a/jitsi_meet/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPlugin.kt
+++ b/jitsi_meet/android/src/main/kotlin/com/gunschu/jitsi_meet/JitsiMeetPlugin.kt
@@ -31,7 +31,7 @@ public class JitsiMeetPlugin() : FlutterPlugin, MethodCallHandler, ActivityAware
 
     private var activity: Activity? = null
 
-    constructor(activity: Activity) : this() {
+    constructor(activity: Activity?) : this() {
         this.activity = activity
     }
 


### PR DESCRIPTION
This change resolves #385 

After upgrading Flutter to 3.0, jitsi_meet was showing error as
jitsi_meet\JitsiMeetPlugin.kt: (66, 42): Type mismatch: inferred type is Activity? but Activity was expected

### Description
<!-- Describe the changes you are proposing. Keep PRs small and addressing one issue/feature at a time. -->

### Type of change, choose all that apply. (Put an 'x' in the boxes)
* [ ] breaking
* [x] fix
* [ ] feature
* [ ] docs
* [ ] ci
* [ ] tests
* [x] chore (e.g. upgrade of dependencies)

### Test artifacts
Since we do not yet have automated testing please include the following to speed up the review process.
* [ ] Video or screenshots of the functionality, bug fix, or regression testing: 
* [ ] Environments tested in (device, version, etc): 

### Have you updated documentation?
* [ ] yes
* [x] no
