### PR TITLE
Fix: removing "useProguard true" flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ buildTypes {
         // Signing with the debug keys for now, so `flutter run --release` works.
         signingConfig signingConfigs.debug
         
-        // Add below 3 lines for proguard
+        // Add below 2 lines for proguard
         minifyEnabled true
-        useProguard true
         proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
 }


### PR DESCRIPTION
Removing the flag since it has become obsolete
Supporting documents
https://stackoverflow.com/questions/52428973/how-to-minify-a-flutter-app-with-proguard -> https://stackoverflow.com/questions/57635963/gradle-dsl-element-useproguard-is-obsolete-and-will-be-removed-soon

### Description
<!-- Describe the changes you are proposing. Keep PRs small and addressing one issue/feature at a time. -->

### Type of change, choose all that apply. (Put an 'x' in the boxes)
* [ ] breaking
* [x] fix
* [ ] feature
* [x] docs
* [ ] ci
* [ ] tests
* [ ] chore (e.g. upgrade of dependencies)

### Test artifacts
Since we do not yet have automated testing please include the following to speed up the review process.
* [ ] Video or screenshots of the functionality, bug fix, or regression testing: 
* [ ] Environments tested in (device, version, etc): 

### Have you updated documentation?
* [x] yes
* [ ] no
